### PR TITLE
Fix GFF3Reader feature resolution

### DIFF
--- a/aeneas/feature.py
+++ b/aeneas/feature.py
@@ -573,20 +573,18 @@ def test_strand():
     assert f4.strand == '+'
 
     f2.add_child(f3)
-    try:
-        f2.add_child(f4)
-    except AssertionError:
-        pass
+    with pytest.raises(AssertionError) as ae:
+        f2.add_child(f4, rangecheck=True)
+    assert 'has a different strand' in str(ae)
     assert len(f2.children) == 1
     f4._strand = '-'
     f2.add_child(f4)
     assert len(f2.children) == 2
 
     gff3 = ['chr', 'vim', 'EST_match', '57229', '57404', '.', '~', '.', '.']
-    try:
+    with pytest.raises(AssertionError) as ae:
         f5 = Feature('\t'.join(gff3))
-    except AssertionError:
-        pass
+    assert 'invalid strand' in str(ae)
 
 
 def test_phase():

--- a/aeneas/feature.py
+++ b/aeneas/feature.py
@@ -176,9 +176,9 @@ class Feature(object):
                     self.fid, self.seqid, child.seqid
                 )
             )
-        assert self._strand == child._strand, \
-            ('child of feature {} has a different strand'.format(self.fid))
         if rangecheck is True:
+            assert self._strand == child._strand, \
+                ('child of feature {} has a different strand'.format(self.fid))
             assert self._region.contains(child._region), \
                 (
                     'child of feature {} is not contained within its span '

--- a/aeneas/reader.py
+++ b/aeneas/reader.py
@@ -92,9 +92,6 @@ class GFF3Reader():
                         assert feature.type == other.type, \
                             'feature type disagreement for ID="%s": %s vs %s' \
                             % (featureid, feature.type, other.type)
-                        assert feature.seqid == other.seqid, \
-                            'feature seq disagreement for ID="%s": %s vs %s' \
-                            % (featureid, feature.seqid, other.seqid)
                         other.add_sibling(feature)
                     else:
                         self.featsbyid[featureid] = feature
@@ -109,10 +106,6 @@ class GFF3Reader():
             parent = self.featsbyid[parentid]
             for child in self.featsbyparent[parentid]:
                 parent.add_child(child, rangecheck=self.strict)
-                if child.is_multi:
-                    for sibling in child.multi_rep.siblings:
-                        if sibling != child:
-                            parent.add_child(sibling, rangecheck=self.strict)
 
         for record in sorted(self.records):
             yield record

--- a/aeneas/reader.py
+++ b/aeneas/reader.py
@@ -245,6 +245,5 @@ def test_id_mismatch():
     with pytest.raises(AssertionError) as ae:
         for record in reader:
             pass  # pragma: no cover
-    testmessage = ('feature seq disagreement for ID="LH19950": scaffold2 vs '
-                   'scaffold1')
+    testmessage = 'seqid mismatch for feature LH19950'
     assert testmessage in str(ae.value)


### PR DESCRIPTION
Handling siblings was unnecessary and dramatically increased runtime.