### PR TITLE
Fix GFF3Reader open

### DIFF
--- a/tag/range.py
+++ b/tag/range.py
@@ -32,7 +32,7 @@ class Range(object):
         assert start >= 0, ('start coordinate {} invalid, must be an '
                             'integer >= 0'.format(start))
         assert end >= 0, ('end coordinate {} invalid,  must be an '
-                          'integer > 0'.format(start))
+                          'integer >= 0'.format(end))
         assert start <= end, ('coordinates [{}, {}] invalid, start must be '
                               '<= end'.format(start, end))
         self._start = start
@@ -81,9 +81,9 @@ class Range(object):
 
     @start.setter
     def start(self, newstart):
-        assert newstart > 0, \
+        assert newstart >= 0, \
             ('new start coordinate {} invalid, must be an '
-             'integer > 0'.format(newstart))
+             'integer >= 0'.format(newstart))
         assert newstart <= self._end, \
             ('new start coordinate {} invalid, must '
              'be <= end {}'.format(newstart, self._end))
@@ -95,9 +95,9 @@ class Range(object):
 
     @end.setter
     def end(self, newend):
-        assert newend > 0, \
+        assert newend >= 0, \
             ('new end coordinate {} invalid, must be an '
-             'integer > 0'.format(newend))
+             'integer >= 0'.format(newend))
         assert self._start <= newend, \
             ('new end coordinate {} is invalid, '
              'must be >= start {}'.format(newend, self._start))

--- a/tag/reader.py
+++ b/tag/reader.py
@@ -8,6 +8,7 @@
 # -----------------------------------------------------------------------------
 
 import sys
+import tag
 from tag.range import Range
 from tag.comment import Comment
 from tag.directive import Directive
@@ -70,7 +71,7 @@ class GFF3Reader():
         self.instream = instream
         if infilename:
             self.infilename = infilename
-            self.instream = open(infilename, 'r')
+            self.instream = tag.open(infilename, 'r')
         self.assumesorted = assumesorted
         self.strict = strict
         self.declared_regions = dict()

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -211,3 +211,11 @@ def test_seqreg_outoforder():
     reader = GFF3Reader(instream=infile, assumesorted=True)
     with pytest.raises(ValueError) as ve:
         records = [r for r in reader]
+
+
+def test_gzip_input():
+    reader = GFF3Reader(infilename='tests/testdata/gzipdata.gff3.gz')
+    records = [r for r in reader]
+    assert len(records) == 5
+    genes = [r for r in records if hasattr(r, 'type') and r.type == 'gene']
+    assert len(genes) == 3


### PR DESCRIPTION
The GFF3Reader currently uses Python's default `open` command, instead of the preferred `tag.open` which has intelligent gzip support. This PR fixes the problem.