### PR TITLE
Fix missing ##FASTA directives, better handling of feature scores

### DIFF
--- a/tag/__init__.py
+++ b/tag/__init__.py
@@ -19,6 +19,7 @@ from tag.sequence import Sequence
 from tag.range import Range
 from tag.reader import GFF3Reader
 from tag.writer import GFF3Writer
+from tag.score import Score
 from tag import cli
 from tag import select
 from tag import mrna

--- a/tag/feature.py
+++ b/tag/feature.py
@@ -12,6 +12,7 @@ from tag.comment import Comment
 from tag.directive import Directive
 from tag.range import Range
 from tag.sequence import Sequence
+from tag.score import Score
 
 
 class Feature(object):
@@ -27,7 +28,7 @@ class Feature(object):
     'gene'
     >>> feature.start, feature.end
     (999, 7500)
-    >>> feature.score is None
+    >>> feature.score.value is None
     True
     >>> feature.strand
     '+'
@@ -59,10 +60,7 @@ class Feature(object):
         self._source = fields[1]
         self._type = fields[2]
         self._range = Range(int(fields[3]) - 1, int(fields[4]))
-        if fields[5] == '.':
-            self.score = None
-        else:
-            self.score = float(fields[5])
+        self.score = Score(fields[5])
         self._strand = fields[6]
         if fields[7] == '.':
             self.phase = None
@@ -78,15 +76,12 @@ class Feature(object):
 
     def __str__(self):
         """String representation of the feature, sans children."""
-        score = '.'
-        if self.score is not None:
-            score = "{:.3f}".format(self.score)
         phase = '.'
         if self.phase is not None:
             phase = str(self.phase)
         return '\t'.join([
             self.seqid, self.source, self.type, str(self.start + 1),
-            str(self.end), score, self.strand, phase, self.attributes
+            str(self.end), str(self.score), self.strand, phase, self.attributes
         ])
 
     def __repr__(self):

--- a/tag/feature.py
+++ b/tag/feature.py
@@ -28,7 +28,7 @@ class Feature(object):
     'gene'
     >>> feature.start, feature.end
     (999, 7500)
-    >>> feature.score.value is None
+    >>> feature.score is None
     True
     >>> feature.strand
     '+'
@@ -60,7 +60,7 @@ class Feature(object):
         self._source = fields[1]
         self._type = fields[2]
         self._range = Range(int(fields[3]) - 1, int(fields[4]))
-        self.score = Score(fields[5])
+        self._score = Score(fields[5])
         self._strand = fields[6]
         if fields[7] == '.':
             self.phase = None
@@ -81,7 +81,8 @@ class Feature(object):
             phase = str(self.phase)
         return '\t'.join([
             self.seqid, self.source, self.type, str(self.start + 1),
-            str(self.end), str(self.score), self.strand, phase, self.attributes
+            str(self.end), str(self._score), self.strand, phase,
+            self.attributes
         ])
 
     def __repr__(self):
@@ -230,6 +231,10 @@ class Feature(object):
     @property
     def fid(self):
         return self.get_attribute('ID')
+
+    @property
+    def score(self):
+        return self._score.value
 
     @property
     def slug(self):

--- a/tag/score.py
+++ b/tag/score.py
@@ -16,20 +16,20 @@ class Score(object):
     def __init__(self, datastr):
         self._type = None
         if datastr == '.':
-            self.score = None
+            self.value = None
         elif re.search('^-*\d+$', datastr):
-            self.score = int(datastr)
+            self.value = int(datastr)
             self._type = int
         else:
-            self.score = float(datastr)
+            self.value = float(datastr)
             self._type = float
 
     def __str__(self):
-        if self.score is None:
+        if self.value is None:
             return '.'
         elif self._type == int:
-            return '{:d}'.format(self.score)
-        elif abs(self.score) < 1e6 and abs(self.score) > 1e-4:
-            return '{:1.3f}'.format(self.score)
+            return '{:d}'.format(self.value)
+        elif abs(self.value) < 1e6 and abs(self.value) > 1e-4:
+            return '{:1.3f}'.format(self.value)
         else:
-            return '{:1.3E}'.format(self.score)
+            return '{:1.3E}'.format(self.value)

--- a/tag/score.py
+++ b/tag/score.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+#
+# -----------------------------------------------------------------------------
+# Copyright (C) 2017 Daniel Standage <daniel.standage@gmail.com>
+#
+# This file is part of tag (http://github.com/standage/tag) and is licensed
+# under the BSD 3-clause license: see LICENSE.
+# -----------------------------------------------------------------------------
+
+from __future__ import print_function
+import re
+
+
+class Score(object):
+
+    def __init__(self, datastr):
+        self._type = None
+        if datastr == '.':
+            self.score = None
+        elif re.search('^-*\d+$', datastr):
+            self.score = int(datastr)
+            self._type = int
+        else:
+            self.score = float(datastr)
+            self._type = float
+
+    def __str__(self):
+        if self.score is None:
+            return '.'
+        elif self._type == int:
+            return '{:d}'.format(self.score)
+        elif abs(self.score) < 1e6 and abs(self.score) > 1e-4:
+            return '{:1.3f}'.format(self.score)
+        else:
+            return '{:1.3E}'.format(self.score)

--- a/tag/writer.py
+++ b/tag/writer.py
@@ -16,6 +16,7 @@ except ImportError:  # pragma: no cover
 import sys
 import tag
 from tag import Feature
+from tag import Sequence
 from tag import GFF3Reader
 
 
@@ -45,6 +46,7 @@ class GFF3Writer():
             self.outfile = tag.open(outfile, 'w')
         self.retainids = False
         self.feature_counts = defaultdict(int)
+        self._seq_written = False
 
     def __del__(self):
         if self.outfilename != '-' and not isinstance(self.outfile, StringIO):
@@ -62,4 +64,7 @@ class GFF3Writer():
                         feature.add_attribute('ID', fid)
                     else:
                         feature.drop_attribute('ID')
+            if isinstance(entry, Sequence) and not self._seq_written:
+                print('##FASTA', file=self.outfile)
+                self._seq_written = True
             print(repr(entry), file=self.outfile)

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -69,7 +69,7 @@ def test_basic():
 
     gff3[5] = '0.28466'
     f3 = Feature('\t'.join(gff3))
-    assert abs(f3.score - 0.28466) <= 0.00001
+    assert abs(f3.score.value - 0.28466) <= 0.00001
     gff3[5] = '0.285'
     assert '%s' % f3 == '\t'.join(gff3)
 
@@ -186,17 +186,17 @@ def test_score():
     """Test score handling."""
     gff3 = ['chr', 'vim', 'EST_match', '57229', '57404', '.', '+', '.', '.']
     f1 = Feature('\t'.join(gff3))
-    assert f1.score is None
+    assert f1.score.value is None
 
     gff3[5] = '0.97'
     f2 = Feature('\t'.join(gff3))
-    assert abs(f2.score - 0.97) <= 0.00001
+    assert abs(f2.score.value - 0.97) <= 0.00001
     gff3[5] = '0.970'
     assert str(f2) == '\t'.join(gff3)
 
     gff3[5] = '-1.8332'
     f3 = Feature('\t'.join(gff3))
-    assert abs(f3.score + 1.8332) <= 0.00001
+    assert abs(f3.score.value + 1.8332) <= 0.00001
     gff3[5] = '-1.833'
     assert str(f3) == '\t'.join(gff3)
 

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -69,7 +69,7 @@ def test_basic():
 
     gff3[5] = '0.28466'
     f3 = Feature('\t'.join(gff3))
-    assert abs(f3.score.value - 0.28466) <= 0.00001
+    assert abs(f3.score - 0.28466) <= 0.00001
     gff3[5] = '0.285'
     assert '%s' % f3 == '\t'.join(gff3)
 
@@ -186,17 +186,17 @@ def test_score():
     """Test score handling."""
     gff3 = ['chr', 'vim', 'EST_match', '57229', '57404', '.', '+', '.', '.']
     f1 = Feature('\t'.join(gff3))
-    assert f1.score.value is None
+    assert f1.score is None
 
     gff3[5] = '0.97'
     f2 = Feature('\t'.join(gff3))
-    assert abs(f2.score.value - 0.97) <= 0.00001
+    assert abs(f2.score - 0.97) <= 0.00001
     gff3[5] = '0.970'
     assert str(f2) == '\t'.join(gff3)
 
     gff3[5] = '-1.8332'
     f3 = Feature('\t'.join(gff3))
-    assert abs(f3.score.value + 1.8332) <= 0.00001
+    assert abs(f3.score + 1.8332) <= 0.00001
     gff3[5] = '-1.833'
     assert str(f3) == '\t'.join(gff3)
 

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+#
+# -----------------------------------------------------------------------------
+# Copyright (C) 2017 Daniel Standage <daniel.standage@gmail.com>
+#
+# This file is part of tag (http://github.com/standage/tag) and is licensed
+# under the BSD 3-clause license: see LICENSE.
+# -----------------------------------------------------------------------------
+
+from tag import Score
+
+
+def test_basic():
+    for score in ['.', '10', '12.345', '-11', '-98765.432', '-4.555E+09']:
+        assert str(Score(score)) == score
+    assert str(Score('10.0')) == '10.000'
+    assert str(Score('1.32e12')) == '1.320E+12'
+    assert str(Score('1.2e-16')) == '1.200E-16'

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -46,3 +46,12 @@ def test_write_file():
     with open(output, 'r') as testout:
         testoutput2 = testout.read()
     assert testoutput1 == testoutput2, (testoutput1, testoutput2)
+
+
+def test_write_minimus():
+    reader = GFF3Reader(tag.pkgdata('minimus.gff3'))
+    output = StringIO()
+    writer = GFF3Writer(reader, output)
+    writer.write()
+
+    assert output.getvalue() == tag.pkgdata('minimus.gff3').read()

--- a/tests/testdata/minimus.gff3
+++ b/tests/testdata/minimus.gff3
@@ -1,0 +1,6 @@
+##gff-version 3
+##sequence-region minimus 1 10
+minimus	vim	region	4	6	9000	+	.	Note=lolwut
+##FASTA
+>minimus
+GATTACANNN


### PR DESCRIPTION
Previously, the GFF3Writer failed to write the `##FASTA` directive for output containing sequence records. Also, the Feature class used a single format for printing all numeric values, which was not ideal for small integers, floating point real numbers, and large integers in scientific notation.

This PR introduces fixes to these two problems.